### PR TITLE
X11 support for X86_64

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,12 +4,26 @@ const std = @import("std");
 // declaratively construct a build graph that will be executed by an external
 // runner.
 //
+//
+const DisplayServer = enum {
+    X11,
+    Wayland
+};
 
 // TODO: comptime check min version of zig and assert 0.14.0
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+
+    const display_server = b.option(
+        DisplayServer, 
+        "DisplayServer", 
+        "Choose linux display server, (X11 or Wayland)"
+    ) orelse .X11;
+
+    const options = b.addOptions();
+    options.addOption(DisplayServer, "DisplayServer", display_server);
 
     const opt_str = switch (optimize) {
         .Debug => "debug",
@@ -166,6 +180,7 @@ pub fn build(b: *std.Build) void {
 
         .linux => {
             zgl.link_libcpp = true; // wgpu need cpp std lib
+
             
             glfw.addCSourceFiles(.{
                 .root = glfw_dep.path("src"),
@@ -211,7 +226,15 @@ pub fn build(b: *std.Build) void {
 
             glfw.addIncludePath(b.path("x11-headers/"));
             const system_sdk = b.dependency("system_sdk", .{});
-            zgl.addObjectFile(system_sdk.path("linux/lib/x86_64-linux-gnu/libX11.so"));
+            // TODO: switch on display_server 
+            if (target.result.cpu.arch.isX86()) {
+                zgl.addObjectFile(system_sdk.path("linux/lib/x86_64-linux-gnu/libX11.so"));
+            }
+
+            if (target.result.cpu.arch.isArm()) {
+                @panic("arch not yet implemented");
+                // zgl.addObjectFile(system_sdk.path("linux/lib/aarch64-linux-gnu/libX11.so"));
+            }
 
         },
         else => @panic("Unsupported OS")

--- a/build.zig
+++ b/build.zig
@@ -36,7 +36,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
         .link_libc = true,
-        .strip = true
+        // .strip = true
     });
 
 
@@ -46,7 +46,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
         .link_libc = true,
-        .strip = true
+        // .strip = true
     });
 
     const wgpu_pkg_name = b.fmt("wgpu_{s}_{s}_{s}", .{os_str, arch_str, opt_str});
@@ -209,7 +209,15 @@ pub fn build(b: *std.Build) void {
             // glfw.addIncludePath(b.path("wayland-headers/wayland"));
             // glfw.addIncludePath(b.path("wayland-headers/wayland-protocols"));
             glfw.addIncludePath(b.path("x11-headers/"));
-            glfw.linkSystemLibrary("X11");
+            
+            // b.addSearchPrefix("lib/x86_64-linux-gnu");
+            const system_sdk = b.dependency("system_sdk", .{});
+            // glfw.addLibraryPath(b.path("lib/x86_64-linux-gnu"));
+            // glfw.addLibraryPath(system_sdk.path("linux/lib/x86_64-linux-gnu"));
+            // glfw.linkSystemLibrary("X11");
+            // zgl.linkSystemLibrary("X11", .{});
+            zgl.addObjectFile(system_sdk.path("linux/lib/x86_64-linux-gnu/libX11.so"));
+            // glfw.addObjectFile(b.path("lib/x86_64-linux-gnu/libX11.a"));
 
         },
         else => @panic("Unsupported OS")

--- a/build.zig
+++ b/build.zig
@@ -208,16 +208,10 @@ pub fn build(b: *std.Build) void {
             });
             // glfw.addIncludePath(b.path("wayland-headers/wayland"));
             // glfw.addIncludePath(b.path("wayland-headers/wayland-protocols"));
+
             glfw.addIncludePath(b.path("x11-headers/"));
-            
-            // b.addSearchPrefix("lib/x86_64-linux-gnu");
             const system_sdk = b.dependency("system_sdk", .{});
-            // glfw.addLibraryPath(b.path("lib/x86_64-linux-gnu"));
-            // glfw.addLibraryPath(system_sdk.path("linux/lib/x86_64-linux-gnu"));
-            // glfw.linkSystemLibrary("X11");
-            // zgl.linkSystemLibrary("X11", .{});
             zgl.addObjectFile(system_sdk.path("linux/lib/x86_64-linux-gnu/libX11.so"));
-            // glfw.addObjectFile(b.path("lib/x86_64-linux-gnu/libX11.a"));
 
         },
         else => @panic("Unsupported OS")

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -52,6 +52,10 @@
         //    .lazy = false,
         //},
         //
+         .system_sdk = .{
+            .url = "https://github.com/zig-gamedev/system_sdk/archive/bf49d627a191e339f70e72668c8333717fb969b0.tar.gz",
+            .hash = "122047a9298c4c9dd43389d418d6826d469b192246ba0944102964cdc57f94c562df",
+        },
         .glfw = .{
             .url = "https://github.com/glfw/glfw/releases/download/3.4/glfw-3.4.zip",
             .hash = "1220625fa7ce79733c6889844cb02ea1f6e4b81b46a3fabacec181714879947f4abd"
@@ -104,6 +108,7 @@
         "build.zig",
         "build.zig.zon",
         "src",
+        "lib"
         // For example...
         //"LICENSE",
         //"README.md",

--- a/examples/glfw_window/build.zig
+++ b/examples/glfw_window/build.zig
@@ -1,0 +1,53 @@
+
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe = b.addExecutable(.{
+        .name = "glfw_window",
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+        .strip = true
+    });
+
+    const zgl = b.dependency("zgl", .{
+        .target = target,
+        .optimize = optimize
+    });
+    exe.root_module.addImport("zgl", zgl.module("zgl"));
+    
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+
+    run_cmd.step.dependOn(b.getInstallStep());
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    // This creates a build step. It will be visible in the `zig build --help` menu,
+    // and can be selected like this: `zig build run`
+    // This will evaluate the `run` step rather than the default, which is "install".
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+
+    const exe_unit_tests = b.addTest(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
+
+    // Similar to creating the run step earlier, this exposes a `test` step to
+    // the `zig build --help` menu, providing a way for the user to request
+    // running the unit tests.
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_exe_unit_tests.step);
+}

--- a/examples/glfw_window/build.zig.zon
+++ b/examples/glfw_window/build.zig.zon
@@ -1,0 +1,17 @@
+.{
+    .name = "glfw_window",
+    .version = "0.0.0",
+    .dependencies = .{
+        .zgl = .{
+            .path = "../../",
+        }
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        // For example...
+        //"LICENSE",
+        //"README.md",
+    },
+}

--- a/examples/glfw_window/src/main.zig
+++ b/examples/glfw_window/src/main.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+const glfw = @import("zgl").glfw;
+
+
+pub fn main() !void {
+
+    try glfw.init();
+    defer glfw.terminate();
+
+    const window = try glfw.Window.Create(500, 500, "AAAA WINDOOOW");
+    defer window.destroy();
+
+
+    while (!window.ShouldClose()) {
+        glfw.pollEvents();
+    }
+
+}

--- a/src/glfw.zig
+++ b/src/glfw.zig
@@ -140,7 +140,7 @@ pub fn GetWGPUSurface(window: Window, instance: Instance) wgpu.WGPUError!Surface
             return try GetWGPUMetalSurface(window, instance);
         },
         .linux => {
-            @panic("not yet implemented");
+            return try GetWGPUX11Surface(window, instance);
         },
         .windows => {
             return try GetWGPUWindowsSurface(window, instance);
@@ -181,11 +181,12 @@ fn GetWGPUWindowsSurface(window: Window, instance: Instance) wgpu.WGPUError!Surf
 }
 
 
+//TODO: make optionals and check null
 extern "c" fn glfwGetX11Display() *anyopaque;
-extern "c" fn glfwGetX11Window() *GLFWwindow;
-fn GetWGPUX11Surface() wgpu.WGPUError!Surface {
+extern "c" fn glfwGetX11Window(handle: *GLFWwindow) *GLFWwindow;
+fn GetWGPUX11Surface(window: Window, instance: Instance) wgpu.WGPUError!Surface {
     const x11_display = glfwGetX11Display();
-    const x11_window = glfwGetX11Window();
+    const x11_window = glfwGetX11Window(window._impl);
 
     const fromX11 = Surface.DescriptorFromXlibWindow{
         .window = @intFromPtr(x11_window),
@@ -196,7 +197,7 @@ fn GetWGPUX11Surface() wgpu.WGPUError!Surface {
         .nextInChain = &fromX11.chain,
     };
 
-    return try Instance.CreateSurface(&surface_desc);
+    return try instance.CreateSurface(&surface_desc);
 }
     
 pub extern "c" fn glfwGetCocoaWindow(window: *GLFWwindow) *anyopaque;


### PR DESCRIPTION
Adds support for X11 on x86_64-linux-gnu. Closes #8.
Still has some bugs, for example, it shows whats behind the window before
showing the surface for a split second.

- **testing if addobjectfile works**
- **added simple glfw window example**
- **removed commented code, X11 windowing is working**
- **GLFW can get a X11 Surface**
- **X11 support implemented (for x86_64)**
